### PR TITLE
README: Add swagger-js-codegen.queries and fix closing punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,18 @@
 ```javascript
     grunt.initConfig({
         'swagger-js-codegen': {
-            options: {
-                apis: [
-                    {
-                        swagger: 'swagger/_queries',
-                        moduleName: 'Model' // This is the model and file name
-                    }
-                ],
-                dest: 'lib'
-            },
-            dist: {
+            queries: {
+                options: {
+                    apis: [
+                        {
+                            swagger: 'swagger/_queries',
+                            moduleName: 'Model' // This is the model and file name
+                        }
+                    ],
+                    dest: 'lib'
+                },
+                dist: {
+                }
             }
         }
     });
@@ -28,17 +30,19 @@
 ```javascript
     grunt.initConfig({
         'swagger-js-codegen': {
-            options: {
-                apis: [
-                    {
-                        swagger: 'swagger/_queries',
-                        moduleName: 'Model', // This is the model and file name
-                        angularjs: true
-                    }
-                ],
-                dest: 'lib'
-            },
-            dist: {
+            queries: {
+                options: {
+                    apis: [
+                        {
+                            swagger: 'swagger/_queries',
+                            moduleName: 'Model', // This is the model and file name
+                            angularjs: true
+                        }
+                    ],
+                    dest: 'lib'
+                },
+                dist: {
+                }
             }
         }
     });


### PR DESCRIPTION
`swagger-js-codegen` has been a multi-task since 6173c732 (First
commit, 2014-06-15), and [multi-tasks need named sub-properties to
iterate over](http://gruntjs.com/api/grunt.task#grunt.task.registermultitask).  I don't see much point to both having a multi-task
and an array for `apis`.  Perhaps we should have:

```
'swagger-js-codegen': {
  batch: {
    options: {
      api: {
        swagger: 'swagger/_batch.json',
        moduleName: 'Batch'
      },
      dest: 'lib'
    },
  },
  queries: {
    options: {
      api: {
        swagger: 'swagger/_queries.json',
        moduleName: 'Queries'
      },
      dest: 'lib'
    },
  },
}
```

which would allow both the complete:

```
$ grunt swagger-js-codegen
```

and the per-API:

```
$ grunt swagger-js-codegen:queries
```
