### PR TITLE
Passing custom parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@
                         {
                             swagger: 'swagger/_queries',
                             moduleName: 'Model' // This is the file name
-							mustache: {
-								moduleName: 'Model'	// This is the model name - it should be repeated here if you want to use it in mustache templates
-								customParam: 'foo'	//some custom param used in mustache templates
-							},
-							template: {
-							  class: fs.readFileSync('custom-angular-class.mustache', 'utf-8'),
-							  method: fs.readFileSync('custom-method.mustache', 'utf-8'),
-							  request: fs.readFileSync('custom-angular-request.mustache', 'utf-8')
-							},
-							custom : true
+                            mustache: {
+                                moduleName: 'Model' // This is the model name - it should be repeated here if you want to use it in mustache templates
+                                customParam: 'foo'  //some custom param used in mustache templates
+                            },
+                            template: {
+                              class: fs.readFileSync('custom-angular-class.mustache', 'utf-8'),
+                              method: fs.readFileSync('custom-method.mustache', 'utf-8'),
+                              request: fs.readFileSync('custom-angular-request.mustache', 'utf-8')
+                            },
+                            custom : true
                         }
                     ],
                     dest: 'lib'

--- a/README.md
+++ b/README.md
@@ -48,3 +48,32 @@
     });
 ```
 
+###Custom generation
+```javascript
+    grunt.initConfig({
+        'swagger-js-codegen': {
+            queries: {
+                options: {
+                    apis: [
+                        {
+                            swagger: 'swagger/_queries',
+                            moduleName: 'Model' // This is the file name
+							mustache: {
+								moduleName: 'Model'	// This is the model name - it should be repeated here if you want to use it in mustache templates
+								customParam: 'foo'	//some custom param used in mustache templates
+							},
+							template: {
+							  class: fs.readFileSync('custom-angular-class.mustache', 'utf-8'),
+							  method: fs.readFileSync('custom-method.mustache', 'utf-8'),
+							  request: fs.readFileSync('custom-angular-request.mustache', 'utf-8')
+							},
+							custom : true
+                        }
+                    ],
+                    dest: 'lib'
+                },
+                dist: {
+                }
+            }
+        }
+    });

--- a/tasks/swagger-js-codegen.js
+++ b/tasks/swagger-js-codegen.js
@@ -31,7 +31,7 @@ module.exports = function (grunt) {
                         if (api.type === 'angular' || api.angularjs === true) {
                             source = CodeGen.getAngularCode({ moduleName: api.moduleName, className: api.className, swagger: swagger });
                         } else if (api.custom === true) {
-                            source = CodeGen.getCustomCode({ className: api.className, template: api.template, swagger: swagger });
+                            source = CodeGen.getCustomCode({ className: api.className, template: api.template, swagger: swagger, mustache: api.mustache });
                         } else {
                             source = CodeGen.getNodeCode({ className: api.className, swagger: swagger });
                         }
@@ -51,7 +51,7 @@ module.exports = function (grunt) {
                         if (api.type === 'angular' || api.angularjs === true) {
                             source = CodeGen.getAngularCode({ moduleName: api.moduleName, className: api.className, swagger: swagger });
                         } else if (api.custom === true) {
-                            source = CodeGen.getCustomCode({ className: api.className, template: api.template, swagger: swagger });
+                            source = CodeGen.getCustomCode({ className: api.className, template: api.template, swagger: swagger, mustache: api.mustache });
                         } else {
                             source = CodeGen.getNodeCode({ className: api.className, swagger: swagger });
                         }


### PR DESCRIPTION
Hello,
I try to use my own mastache templates to generate AngularJs scripts but the "moduleName" parameter was ommited for custom configuration. In new version of codegenjs there is possibility to add "mustache" section. So I add it in swagger-js-codegen.js.
I have one more problem. I try to use default mastache templates in a custom configuration (without any changes, just put these files in gruntfile.js path and chanage config for:
template: {
                  class: fs.readFileSync('angular-class.mustache', 'utf-8'),
                  method: fs.readFileSync('method.mustache', 'utf-8'),
                  request: fs.readFileSync('angular-request.mustache', 'utf-8')
              },
              custom : true
) 
but I have got warning "An error occurred while processing a template (Unexpected token &). Use --force to continue.". When I parse these templates using AngularJs config (angularjs : true), it is ok.

Regards
Michał Opieliński