### PR TITLE
Add support to YAML/YML files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,11 @@
   ],
   "homepage": "https://github.com/wcandillon/grunt-swagger-js-codegen",
   "dependencies": {
-    "swagger-js-codegen": "1.1.8",
     "lodash": "^2.4.1",
     "q": "^1.0.1",
-    "request": "^2.45.0"
+    "request": "^2.45.0",
+    "swagger-js-codegen": "1.1.8",
+    "yamljs": "^0.2.7"
   },
   "devDependencies": {
     "grunt": "~0.4.4",

--- a/tasks/swagger-js-codegen.js
+++ b/tasks/swagger-js-codegen.js
@@ -71,7 +71,7 @@ module.exports = function (grunt) {
     });
 
     function testIfYamlExtension(filename) {
-        return filename.substring(filename.length - '.yaml'.length) === '.yaml' || filename.substring(filename.length - '.yml'.length) === '.yml';
+        return filename.substring(filename.length - '.yaml'.length).toLowerCase() === '.yaml' || filename.substring(filename.length - '.yml'.length).toLowerCase() === '.yml';
     }
 
     function generateApi(api, swagger, dest, fname) {

--- a/tasks/swagger-js-codegen.js
+++ b/tasks/swagger-js-codegen.js
@@ -1,6 +1,7 @@
 module.exports = function (grunt) {
     'use strict';
     var fs = require('fs');
+    var yaml = require('yamljs');
 
     grunt.registerMultiTask('swagger-js-codegen', 'Swagger codegen for Javascript', function(){
         var request = require('request');
@@ -24,7 +25,18 @@ module.exports = function (grunt) {
                     if(error || response.statusCode !== 200) {
                         deferred.reject('Error while fetching ' + api.swagger + ': ' + (error || body));
                     } else {
-                        generateApi(api, body, dest, fname);
+                        var swagger = JSON.parse(body);
+                        generateApi(api, swagger, dest, fname);
+                        deferred.resolve();
+                    }
+                });
+            } else if(testIfYamlExtension(api.swagger)) {
+                fs.readFile(api.swagger, 'UTF-8', function(err, data) {
+                    if(err) {
+                        deferred.reject(err);
+                    } else {
+                        var swagger = yaml.parse(data);
+                        generateApi(api, swagger, dest, fname);
                         deferred.resolve();
                     }
                 });
@@ -33,7 +45,8 @@ module.exports = function (grunt) {
                     if(err) {
                         deferred.reject(err);
                     } else {
-                        generateApi(api, data, dest, fname);
+                        var swagger = JSON.parse(data);
+                        generateApi(api, swagger, dest, fname);
                         deferred.resolve();
                     }
                 });
@@ -57,10 +70,13 @@ module.exports = function (grunt) {
         });
     });
 
-    function generateApi(api, data, dest, fname) {
+    function testIfYamlExtension(filename) {
+        return filename.substring(filename.length - '.yaml'.length) === '.yaml' || filename.substring(filename.length - '.yml'.length) === '.yml';
+    }
+
+    function generateApi(api, swagger, dest, fname) {
         var CodeGen = require('swagger-js-codegen').CodeGen;
-        var swagger = JSON.parse(data),
-          source = null;
+        var source = null;
 
         if (api.type === 'angular' || api.angularjs === true) {
             source = CodeGen.getAngularCode({ moduleName: api.moduleName, className: api.className, swagger: swagger });


### PR DESCRIPTION
This pull request adds support YAML and YML files and resolves #30.

When reading files it checks that if the file ends .yaml or .yml and reads that into object. That object is passed to generateApi that takes 2nd argument called swagger as in object instead of string.
